### PR TITLE
Add starcount translation keys

### DIFF
--- a/zone.py
+++ b/zone.py
@@ -67,6 +67,7 @@ translations = {
         'Exporter Toutes Conservées': "Exporter Toutes Conservées",
         'apply_snr_rejection_button': "Appliquer Rejet SNR",
         'visual_apply_snr_button': "Appliquer Rejet SNR",
+        'apply_starcount_rejection': "Appliquer Rejet Starcount",
 
         # --- Textes acstools status ---
         'acstools_ok': "(acstools disponible)", 'acstools_missing': "(acstools non trouvé ou incompatible)", 'acstools_sig_error': "(fonction detsat incompatible)",
@@ -85,6 +86,10 @@ translations = {
         # --- Fenêtre Visualisation ---
         'visu_window_title': "Visualisation des résultats", 'visu_tab_snr_dist': "Distribution SNR", 'visu_tab_snr_comp': "Comparaison SNR", 'visu_tab_sat_trails': "Traînées Détectées", 'visu_tab_raw_data': "Données Détaillées", 'visu_tab_recom': "Recommandations Stacking",
         'visu_snr_dist_title': 'Distribution du Rapport Signal/Bruit (SNR)', 'visu_snr_dist_xlabel': 'SNR', 'visu_snr_dist_ylabel': 'Nombre d\'images', 'visu_snr_dist_no_data': "Aucune donnée SNR valide",
+        'starcount_distribution_tab': "Distribution Starcount",
+        'starcount_distribution_title': "Distribution Starcount",
+        'starcount_label': "Nombre d'étoiles",
+        'number_of_images': "Nombre d'images",
         'visu_snr_comp_best_title': 'Top {n} Images (Meilleur SNR)', 'visu_snr_comp_worst_title': 'Bottom {n} Images (Pire SNR)', 'visu_snr_comp_xlabel': 'SNR', 'visu_snr_comp_no_data': "Pas assez d'images avec SNR valide pour comparer.",
         'visu_sat_pie_title': 'Proportion d\'images avec/sans traînées détectées', 'visu_sat_pie_with': 'Avec Traînées', 'visu_sat_pie_without': 'Sans Traînées', 'visu_sat_pie_no_data': "Aucune image analysée pour les traînées.",
         'visu_data_col_file': "Fichier (Relatif)", 'visu_data_col_snr': "SNR", 'visu_data_col_bg': "Fond", 'visu_data_col_noise': "Bruit", 'visu_data_col_pixsig': "PixSig", 'visu_data_col_trails': "Traînées?", 'visu_data_col_nbseg': "Nb Seg.",
@@ -95,6 +100,7 @@ translations = {
         # --- Infobulles (Tooltips) ---
         'tooltip_sigma': "Sigma du filtre Gaussien avant détection contours (flou). Défaut: 2.0", 'tooltip_low_thresh': "Seuil bas Canny (0-1). Détecte bords potentiels. Bas=Sensible bruit. Défaut acstools: 0.1", 'tooltip_h_thresh': "Seuil haut Canny (0-1). Ancre bords forts. >= Low Thr. Bas=Permissif. Défaut acstools: 0.5", 'tooltip_line_len': "Longueur min. (px) segment final pour être une traînée. Défaut acstools: 150", 'tooltip_small_edge': "Longueur min. (px) contour initial (par Canny). Filtre bruit avant Hough. Défaut acstools: 60", 'tooltip_line_gap': "Écart max (px) pour joindre segments. Défaut acstools: 75", 'tooltip_snr_value': "Entrez % (ex: 80) ou seuil SNR (ex: 5.5). Ignoré si Tout Garder.",
         'tooltip_apply_snr_rejection': "Appliquer les rejets SNR différés",
+        'tooltip_apply_starcount_rejection': "Appliquer les actions Starcount différées",
 
         # --- Textes Logique ---
         'logic_info_prefix': "INFO: ", 'logic_log_prefix': "LOG: ", 'logic_status_prefix': "STATUS: ", 'logic_warn_prefix': "Avertissement: ", 'logic_error_prefix': "Erreur: ",
@@ -197,6 +203,10 @@ translations = {
         # --- Visualization Window ---
         'visu_window_title': "Results Visualization", 'visu_tab_snr_dist': "SNR Distribution", 'visu_tab_snr_comp': "SNR Comparison", 'visu_tab_sat_trails': "Detected Trails", 'visu_tab_raw_data': "Detailed Data", 'visu_tab_recom': "Stacking Recommendations",
         'visu_snr_dist_title': 'Signal-to-Noise Ratio (SNR) Distribution', 'visu_snr_dist_xlabel': 'SNR', 'visu_snr_dist_ylabel': 'Number of images', 'visu_snr_dist_no_data': "No valid SNR data",
+        'starcount_distribution_tab': "Starcount Distribution",
+        'starcount_distribution_title': "Starcount Distribution",
+        'starcount_label': "Starcount",
+        'number_of_images': "Number of images",
         'visu_snr_comp_best_title': 'Top {n} Images (Best SNR)', 'visu_snr_comp_worst_title': 'Bottom {n} Images (Worst SNR)', 'visu_snr_comp_xlabel': 'SNR', 'visu_snr_comp_no_data': "Not enough images with valid SNR to compare.",
         'visu_sat_pie_title': 'Proportion of images with/without detected trails', 'visu_sat_pie_with': 'With Trails', 'visu_sat_pie_without': 'Without Trails', 'visu_sat_pie_no_data': "No images analyzed for trails.",
         'visu_data_col_file': "File (Relative)", 'visu_data_col_snr': "SNR", 'visu_data_col_bg': "BG", 'visu_data_col_noise': "Noise", 'visu_data_col_pixsig': "SigPix", 'visu_data_col_trails': "Trails?", 'visu_data_col_nbseg': "Nb Seg.",
@@ -207,6 +217,7 @@ translations = {
         # --- Tooltips ---
         'tooltip_sigma': "Sigma of Gaussian filter before edge detection (blur). Default: 2.0", 'tooltip_low_thresh': "Lower Canny threshold (0-1). Detects potential edges. Lower=Noisier. acstools default: 0.1", 'tooltip_h_thresh': "Upper Canny threshold (0-1). Anchors strong edges. >= Low Thr. Lower=Permissive. acstools default: 0.5", 'tooltip_line_len': "Min. length (px) of final line segment to be a trail. acstools default: 150", 'tooltip_small_edge': "Min. length (px) of initial edge segment (Canny). Filters noise before Hough. acstools default: 60", 'tooltip_line_gap': "Max allowed gap (px) to link segments. acstools default: 75", 'tooltip_snr_value': "Enter % (e.g., 80) or SNR threshold (e.g., 5.5). Ignored if Keep All.",
         'tooltip_apply_snr_rejection': "Apply pending SNR rejections",
+        'tooltip_apply_starcount_rejection': "Apply pending starcount actions",
 
         # --- Logic Texts ---
         'logic_info_prefix': "INFO: ", 'logic_log_prefix': "LOG: ", 'logic_status_prefix': "STATUS: ", 'logic_warn_prefix': "Warning: ", 'logic_error_prefix': "Error: ",
@@ -234,6 +245,7 @@ translations = {
         'marker_delete_errors': "Errors occurred while deleting some markers:\n",
         'marker_delete_selected_success': "{count} marker(s) deleted.",
         'marker_delete_all_success': "All {count} found marker(s) deleted.",
+        'apply_starcount_rejection': "Apply Starcount Rejection",
         
         #--- Apply SNR
         'apply_snr_rejection_button': "Apply SNR Rejection",


### PR DESCRIPTION
## Summary
- add missing keys for starcount distribution in `zone.py`

## Testing
- `python -m py_compile zone.py`
- `python -m py_compile analyse_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68671aeabb04832fafd6c424a3102d9d