### PR TITLE
Add starcount metric support

### DIFF
--- a/starcount_module.py
+++ b/starcount_module.py
@@ -1,0 +1,15 @@
+import numpy as np
+from astropy.stats import sigma_clipped_stats
+from photutils.detection import DAOStarFinder
+
+
+def calculate_starcount(data, fwhm=3.5, threshold_sigma=5.0):
+    """Return number of stars detected in ``data`` using DAOStarFinder."""
+    try:
+        mean, median, std = sigma_clipped_stats(data, sigma=3.0)
+        finder = DAOStarFinder(fwhm=fwhm, threshold=threshold_sigma * std)
+        sources = finder(data - median)
+        return 0 if sources is None else len(sources)
+    except Exception:
+        return 0
+


### PR DESCRIPTION
## Summary
- implement `starcount_module.calculate_starcount`
- import and call starcount metric in `analyse_logic` during FITS processing
- allow optional threshold-based rejection and include starcount stats in logs
- always compute starcount for each FITS file

## Testing
- `python -m py_compile analyse_logic.py starcount_module.py`
- `python - <<'EOF'
import numpy as np, starcount_module
arr=np.zeros((10,10))
print('count', starcount_module.calculate_starcount(arr))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68671dee9370832fb1c4f9c6556f78bf