### PR TITLE
Implement Apply Recommendations feature

### DIFF
--- a/zone.py
+++ b/zone.py
@@ -68,6 +68,8 @@ translations = {
         'apply_snr_rejection_button': "Appliquer Rejet SNR",
         'visual_apply_snr_button': "Appliquer Rejet SNR",
         'apply_starcount_rejection': "Appliquer Rejet Starcount",
+        'apply_reco_button': "Appliquer Recommandations",
+        'visual_apply_reco_button': "Appliquer Recommandations",
 
         # --- Textes acstools status ---
         'acstools_ok': "(acstools disponible)", 'acstools_missing': "(acstools non trouvé ou incompatible)", 'acstools_sig_error': "(fonction detsat incompatible)",
@@ -280,7 +282,9 @@ translations = {
         'marker_delete_selected_success': "{count} marker(s) deleted.",
         'marker_delete_all_success': "All {count} found marker(s) deleted.",
         'apply_starcount_rejection': "Apply Starcount Rejection",
-        
+        'apply_reco_button': "Apply Recommendations",
+        'visual_apply_reco_button': "Apply Recommendations",
+
         #--- Apply SNR
         'apply_snr_rejection_button': "Apply SNR Rejection",
         'visual_apply_snr_button': "Apply SNR Rejection",


### PR DESCRIPTION
## Summary
- add "Apply Recommendations" buttons in main and visualization windows
- compute recommended images after analysis and enable buttons when available
- implement application logic `_apply_recommendations_gui`
- add `apply_pending_reco_actions` in `analyse_logic`
- extend translations for new buttons

## Testing
- `python -m py_compile analyse_gui.py analyse_logic.py zone.py`

------
https://chatgpt.com/codex/tasks/task_e_686796da6710832fabdc92899f2b4c53