### PR TITLE
Support stacker language management

### DIFF
--- a/zone.py
+++ b/zone.py
@@ -303,6 +303,15 @@ translations = {
         "Échec application rejets SNR.": "Failed applying SNR rejections.",
 
 
+# Fin du dictionnaire de traductions
     }
 }
+
+# Fallback pour la fonction de traduction
+try:
+    from zeseestarstacker.i18n import _
+except ImportError:
+    def _(key, *args, **kwargs):
+        return translations.get('fr', {}).get(key, key)
+
 # --- FIN DU FICHIER zone.py ---


### PR DESCRIPTION
## Summary
- detect if running under zeseestarstacker
- allow AstroImageAnalyzerGUI to auto-lock language
- hide language selector when locked
- add translation fallback when vendored

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python analyse_gui.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6867a495fca4832fbfa4870218bf072f