### PR TITLE
Validate Bortle raster inputs

### DIFF
--- a/analyse_gui.py
+++ b/analyse_gui.py
@@ -990,9 +990,19 @@ class AstroImageAnalyzerGUI:
         options['apply_snr_action_immediately'] = False # On veut toujours différer l'action SNR depuis le GUI
         # --- FIN NOUVEAU ---
 
+        if options.get('use_bortle'):
+            bp = options.get('bortle_path', '')
+            if not bp or not bp.lower().endswith(('.tif', '.tiff')):
+                messagebox.showwarning(
+                    self._("msg_warning"),
+                    "Sélectionnez un GeoTIFF Bortle valide avant de lancer l\u2019analyse.",
+                    parent=self.root
+                )
+                return False
+
         if not input_dir or not os.path.isdir(input_dir):
             messagebox.showerror(self._("msg_error"), self._("msg_input_dir_invalid"), parent=self.root)
-            self.stack_after_analysis = False 
+            self.stack_after_analysis = False
             return False
         if not output_log:
             messagebox.showerror(self._("msg_error"), self._("msg_log_file_missing"), parent=self.root)
@@ -2612,6 +2622,13 @@ class AstroImageAnalyzerGUI:
                 elif len(files) > 1:
                     # Simplified selection: take first file
                     path = os.path.join(path, files[0])
+            if not path.lower().endswith(('.tif', '.tiff')):
+                messagebox.showerror(
+                    self._("msg_error"),
+                    "Fichier Bortle non pris en charge : choisissez un GeoTIFF (.tif)",
+                    parent=self.root
+                )
+                return
             self.bortle_path.set(path)
         self.root.after(50, self.root.focus_force)
         self.root.after(100, self.root.lift)

--- a/bortle_utils.py
+++ b/bortle_utils.py
@@ -35,6 +35,8 @@ THRESHOLDS = _load_thresholds()
 
 def load_bortle_raster(path: str):
     """Open and return a rasterio dataset for the Bortle atlas."""
+    if not path.lower().endswith(('.tif', '.tiff')):
+        raise ValueError("Seuls les fichiers GeoTIFF (.tif/.tiff) sont pris en charge")
     return rasterio.open(path, 'r')
 
 

--- a/tests/test_bortle.py
+++ b/tests/test_bortle.py
@@ -4,6 +4,7 @@ import numpy as np
 import rasterio
 from rasterio.transform import from_origin
 from tempfile import NamedTemporaryFile
+import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from bortle_utils import load_bortle_raster, sqm_to_bortle
 
@@ -17,4 +18,11 @@ def test_sqm_to_bortle(tmp_path):
     val = list(ds.sample([(0, 0)]))[0][0]
     cls = sqm_to_bortle(float(val))
     assert cls == 1
+
+
+def test_load_bortle_raster_invalid_extension(tmp_path):
+    bogus = tmp_path / "bortle.tpk"
+    bogus.write_text("dummy")
+    with pytest.raises(ValueError):
+        load_bortle_raster(str(bogus))
 


### PR DESCRIPTION
## Summary
- warn when selecting a non-GeoTIFF Bortle file in the GUI
- check file extension before launching analysis
- ensure `load_bortle_raster` only accepts `.tif`/`.tiff`
- test that invalid extensions raise `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687113c1b7a4832fbdcff928be260800