### PR TITLE
Fix Bortle classification with luminance data

### DIFF
--- a/analyse_logic.py
+++ b/analyse_logic.py
@@ -1207,7 +1207,8 @@ def perform_analysis(input_dir, output_log, options, callbacks):
             if options.get('use_bortle') and bortle_dataset and lon is not None and lat is not None:
                 try:
                     with bortle_lock:
-                        sqm = list(bortle_dataset.sample([(float(lon), float(lat))]))[0][0]
+                        l_ucd = list(bortle_dataset.sample([(float(lon), float(lat))]))[0][0]
+                    sqm = bortle_utils.ucd_to_sqm(float(l_ucd) + 174.0)
                     bortle_class = str(bortle_utils.sqm_to_bortle(float(sqm)))
                 except Exception:
                     bortle_class = 'Unknown'

--- a/bortle_utils.py
+++ b/bortle_utils.py
@@ -1,6 +1,7 @@
 import os
 import json
 import rasterio
+import numpy as np
 
 THRESHOLD_FILE = os.path.join(os.path.dirname(__file__), 'bortle_thresholds.json')
 DEFAULT_THRESHOLDS = {
@@ -38,6 +39,11 @@ def load_bortle_raster(path: str):
     if not path.lower().endswith(('.tif', '.tiff')):
         raise ValueError("Seuls les fichiers GeoTIFF (.tif/.tiff) sont pris en charge")
     return rasterio.open(path, 'r')
+
+
+def ucd_to_sqm(l_ucd: float) -> float:
+    """Convertir un éclairement en µcd/m² en mag/arcsec²."""
+    return 22.0 - 1.0857 * np.log(l_ucd / 174.0)
 
 
 def sqm_to_bortle(sqm: float) -> int:

--- a/tests/test_bortle.py
+++ b/tests/test_bortle.py
@@ -6,7 +6,7 @@ from rasterio.transform import from_origin
 from tempfile import NamedTemporaryFile
 import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from bortle_utils import load_bortle_raster, sqm_to_bortle
+from bortle_utils import load_bortle_raster, sqm_to_bortle, ucd_to_sqm
 
 def test_sqm_to_bortle(tmp_path):
     data = np.full((2, 2), 22.0, dtype=np.float32)
@@ -18,6 +18,11 @@ def test_sqm_to_bortle(tmp_path):
     val = list(ds.sample([(0, 0)]))[0][0]
     cls = sqm_to_bortle(float(val))
     assert cls == 1
+
+
+def test_ucd_to_sqm():
+    # 174 µcd/m² corresponds roughly to 22 mag/arcsec²
+    assert abs(ucd_to_sqm(174.0) - 22.0) < 1e-6
 
 
 def test_load_bortle_raster_invalid_extension(tmp_path):


### PR DESCRIPTION
## Summary
- convert raster luminance values (µcd/m²) to SQM before Bortle lookup
- expose `ucd_to_sqm` helper in `bortle_utils`
- test conversion function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871278460ec832f8619bed995bfea55