### PR TITLE
Fix Bortle sampling for CRS

### DIFF
--- a/analyse_logic.py
+++ b/analyse_logic.py
@@ -1207,7 +1207,7 @@ def perform_analysis(input_dir, output_log, options, callbacks):
             if options.get('use_bortle') and bortle_dataset and lon is not None and lat is not None:
                 try:
                     with bortle_lock:
-                        l_ucd = list(bortle_dataset.sample([(float(lon), float(lat))]))[0][0]
+                        l_ucd = bortle_utils.sample_bortle_dataset(bortle_dataset, float(lon), float(lat))
                     sqm = bortle_utils.ucd_to_sqm(float(l_ucd) + 174.0)
                     bortle_class = str(bortle_utils.sqm_to_bortle(float(sqm)))
                 except Exception:

--- a/bortle_utils.py
+++ b/bortle_utils.py
@@ -1,6 +1,7 @@
 import os
 import json
 import rasterio
+from rasterio.warp import transform
 import numpy as np
 
 THRESHOLD_FILE = os.path.join(os.path.dirname(__file__), 'bortle_thresholds.json')
@@ -39,6 +40,14 @@ def load_bortle_raster(path: str):
     if not path.lower().endswith(('.tif', '.tiff')):
         raise ValueError("Seuls les fichiers GeoTIFF (.tif/.tiff) sont pris en charge")
     return rasterio.open(path, 'r')
+
+
+def sample_bortle_dataset(ds, lon: float, lat: float) -> float:
+    """Return the raw value from the Bortle dataset at the given lon/lat."""
+    if ds.crs and ds.crs.to_string() not in ("EPSG:4326", "WGS84"):
+        lon, lat = transform("EPSG:4326", ds.crs, [lon], [lat])
+        lon = lon[0]; lat = lat[0]
+    return list(ds.sample([(lon, lat)]))[0][0]
 
 
 def ucd_to_sqm(l_ucd: float) -> float:

--- a/tests/test_bortle.py
+++ b/tests/test_bortle.py
@@ -6,7 +6,7 @@ from rasterio.transform import from_origin
 from tempfile import NamedTemporaryFile
 import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from bortle_utils import load_bortle_raster, sqm_to_bortle, ucd_to_sqm
+from bortle_utils import load_bortle_raster, sqm_to_bortle, ucd_to_sqm, sample_bortle_dataset
 
 def test_sqm_to_bortle(tmp_path):
     data = np.full((2, 2), 22.0, dtype=np.float32)
@@ -15,7 +15,7 @@ def test_sqm_to_bortle(tmp_path):
     with rasterio.open(tif, 'w', driver='GTiff', height=2, width=2, count=1, dtype='float32', transform=transform) as dst:
         dst.write(data, 1)
     ds = load_bortle_raster(str(tif))
-    val = list(ds.sample([(0, 0)]))[0][0]
+    val = sample_bortle_dataset(ds, 0.0, 0.0)
     cls = sqm_to_bortle(float(val))
     assert cls == 1
 
@@ -30,4 +30,25 @@ def test_load_bortle_raster_invalid_extension(tmp_path):
     bogus.write_text("dummy")
     with pytest.raises(ValueError):
         load_bortle_raster(str(bogus))
+
+
+def test_sample_bortle_dataset_transform(tmp_path):
+    data = np.array([[22.0]], dtype=np.float32)
+    transform = from_origin(1113194.0, 0, 1, 1)
+    tif = tmp_path / "bortle_3857.tif"
+    with rasterio.open(
+        tif,
+        'w',
+        driver='GTiff',
+        height=1,
+        width=1,
+        count=1,
+        dtype='float32',
+        crs='EPSG:3857',
+        transform=transform,
+    ) as dst:
+        dst.write(data, 1)
+    ds = load_bortle_raster(str(tif))
+    val = sample_bortle_dataset(ds, 10.0, 0.0)
+    assert val == pytest.approx(22.0)
 


### PR DESCRIPTION
## Summary
- add CRS-aware sampling in `bortle_utils.sample_bortle_dataset`
- use the helper when computing Bortle class in analysis
- test CRS transformation in Bortle utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871320ffc6c832f8bc0df172f99458a