### PR TITLE
Store Bortle raster path in settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 bortle_thresholds.json
+settings.json

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The Bortle analysis relies on the dataset by:
 Falchi, Fabio; Cinzano, Pierantonio; Duriscoe, Dan; Kyba, Christopher C. M.; Elvidge, Christopher D.; Baugh, Kimberly; Portnov, Boris; Rybnikova, Nataliya A.; Furgoni, Riccardo (2016): *Supplement to: The New World Atlas of Artificial Night Sky Brightness. V. 1.1.* GFZ Data Services. <https://doi.org/10.5880/GFZ.1.4.2016.001>
 (study: <https://www.science.org/doi/10.1126/sciadv.1600377>). Download their raster to classify your data by Bortle.
 
+Store the location of this raster in a `settings.json` file at the project root. The application will update this file automatically when you select the raster in the GUI.
+
 L'analyse Bortle repose sur le jeu de données de :
 Falchi, Fabio; Cinzano, Pierantonio; Duriscoe, Dan; Kyba, Christopher C. M.; Elvidge, Christopher D.; Baugh, Kimberly; Portnov, Boris; Rybnikova, Nataliya A.; Furgoni, Riccardo (2016) : *Supplement to: The New World Atlas of Artificial Night Sky Brightness. V. 1.1.* GFZ Data Services. <https://doi.org/10.5880/GFZ.1.4.2016.001>
 (étude : <https://www.science.org/doi/10.1126/sciadv.1600377>). Il faut télécharger ce raster pour pouvoir classer les données par Bortle.

--- a/analyse_gui.py
+++ b/analyse_gui.py
@@ -43,6 +43,7 @@ import argparse # Pour gérer les arguments de ligne de commande
 from PIL import Image, ImageTk
 # L'import de ToolTip est déplacé APRES l'ajustement de sys.path
 import json
+import settings_utils
 import importlib.util
 import numbers
 
@@ -631,6 +632,7 @@ class AstroImageAnalyzerGUI:
 
         self.config_path = os.path.join(os.path.expanduser('~'), 'zeanalyser_gui_config.json')
         self._config_data = self._load_gui_config()
+        self._settings = settings_utils.load_settings()
 
         # Variables Tkinter pour lier les widgets aux données
         self.current_lang = tk.StringVar(value=initial_lang)
@@ -654,7 +656,8 @@ class AstroImageAnalyzerGUI:
         self.detect_trails = tk.BooleanVar(value=False)
         self.sort_by_snr = tk.BooleanVar(value=True)
         self.include_subfolders = tk.BooleanVar(value=False)
-        self.bortle_path = tk.StringVar(value=self._config_data.get('bortle_path', ''))
+        bortle_default = self._settings.get('bortle_path', self._config_data.get('bortle_path', ''))
+        self.bortle_path = tk.StringVar(value=bortle_default)
         self.use_bortle = tk.BooleanVar(value=self._config_data.get('use_bortle', False))
 
         # Paramètres Sélection SNR
@@ -985,6 +988,7 @@ class AstroImageAnalyzerGUI:
         try:
             with open(self.config_path, 'w', encoding='utf-8') as f:
                 json.dump(data, f, indent=2)
+            settings_utils.save_settings({'bortle_path': self.bortle_path.get()})
         except Exception:
             pass
 
@@ -2683,6 +2687,7 @@ class AstroImageAnalyzerGUI:
                 )
                 return
             self.bortle_path.set(path)
+            settings_utils.save_settings({'bortle_path': path})
         self.root.after(50, self.root.focus_force)
         self.root.after(100, self.root.lift)
 

--- a/settings_utils.py
+++ b/settings_utils.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+SETTINGS_FILE = os.path.join(os.path.dirname(__file__), 'settings.json')
+
+def load_settings():
+    """Load settings from SETTINGS_FILE."""
+    if os.path.exists(SETTINGS_FILE):
+        try:
+            with open(SETTINGS_FILE, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+def save_settings(data):
+    """Save settings to SETTINGS_FILE."""
+    try:
+        with open(SETTINGS_FILE, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- add small helper module `settings_utils.py`
- read/write the Bortle raster location via `settings.json`
- update GUI to use these settings and save them when browsing
- document the new settings file and ignore it in git

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a496d970832f9e2032aab05d464e