### PR TITLE
Handle mosaic filenames

### DIFF
--- a/analyse_logic.py
+++ b/analyse_logic.py
@@ -1543,7 +1543,11 @@ def perform_analysis(input_dir, output_log, options, callbacks):
                     date_obj = datetime.datetime.fromisoformat(str(date_obs).split('T')[0])
                 except Exception:
                     pass
-            parts = [output_root, group]
+            filename_lower = os.path.basename(r['path']).lower()
+            if 'mosaic' in filename_lower:
+                parts = [output_root, 'mosaic', group]
+            else:
+                parts = [output_root, group]
             if options.get('use_bortle'):
                 parts.append(f"Bortle_{bortle_class}")
             parts.append(tele)

--- a/tests/test_mosaic_path.py
+++ b/tests/test_mosaic_path.py
@@ -1,0 +1,42 @@
+import os
+import numpy as np
+from astropy.io import fits
+import analyse_logic
+
+
+def test_mosaic_path(tmp_path):
+    input_dir = tmp_path / "in"
+    output_root = tmp_path / "out"
+    input_dir.mkdir()
+    output_root.mkdir()
+    data = np.zeros((10, 10), dtype=np.float32)
+    header = fits.Header()
+    header['EQMODE'] = 1
+    header['TELESCOP'] = 'TestScope'
+    header['FILTER'] = 'L'
+    header['DATE-OBS'] = '2023-08-22T00:00:00'
+    fits_path = input_dir / "image_mosaic_001.fit"
+    fits.writeto(fits_path, data, header)
+
+    options = {
+        'output_root': str(output_root),
+        'analyze_snr': True,
+        'snr_selection_mode': 'none',
+        'use_bortle': False,
+        'detect_trails': False,
+        'analyse_fwhm': False,
+        'analyse_ecc': False,
+    }
+
+    callbacks = {'status': lambda *a, **k: None,
+                 'progress': lambda *a, **k: None,
+                 'log': lambda *a, **k: None}
+
+    log_file = str(tmp_path / "log.txt")
+    results = analyse_logic.perform_analysis(str(input_dir), log_file, options, callbacks)
+
+    assert len(results) == 1
+    dst = results[0]['filepath_dst']
+    assert dst.startswith(str(output_root))
+    expected = os.path.join(str(output_root), 'mosaic', 'EQ', 'TestScope', '2023-08-22', 'Filter_L', 'image_mosaic_001.fit')
+    assert dst == expected


### PR DESCRIPTION
## Summary
- when building destination paths, check filenames for 'mosaic'
- if found, sort them under a `mosaic` directory
- add regression test verifying mosaic path placement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728055411c832fa742f6b24a0bb0f1