### PR TITLE
Fix stack plan not updating after moving files

### DIFF
--- a/analyse_gui.py
+++ b/analyse_gui.py
@@ -4021,6 +4021,10 @@ class AstroImageAnalyzerGUI:
             )
         finally:
             self._update_log_and_vis_buttons_state()
+            try:
+                self._regenerate_stack_plan()
+            except Exception:
+                pass
 
     def _refresh_treeview(self):
         """Placeholder for treeview refresh if implemented."""


### PR DESCRIPTION
## Summary
- ensure the stacking plan CSV is regenerated after file organization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769e058108832f85806a088b067e6f