### PR TITLE
Fix stack plan update after organizing files

### DIFF
--- a/analyse_gui.py
+++ b/analyse_gui.py
@@ -4026,11 +4026,13 @@ class AstroImageAnalyzerGUI:
                 self._("msg_organize_failed", e=e),
             )
         finally:
-            self._update_log_and_vis_buttons_state()
             try:
+                # Mettre à jour le plan de stacking avant de recharger 
+                # éventuellement les résultats depuis le log.
                 self._regenerate_stack_plan()
             except Exception:
                 pass
+            self._update_log_and_vis_buttons_state()
 
     def _refresh_treeview(self):
         """Placeholder for treeview refresh if implemented."""


### PR DESCRIPTION
## Summary
- ensure the stack plan regenerates before results list may be reloaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a64693b8832f8b005577a09c6291