### PR TITLE
Handle permission errors when writing stack plan

### DIFF
--- a/analyse_gui.py
+++ b/analyse_gui.py
@@ -3666,7 +3666,14 @@ class AstroImageAnalyzerGUI:
 
         plan = generate_stacking_plan(kept)
         plan_path = os.path.join(os.path.dirname(self.output_log.get()), "stack_plan.csv")
-        write_stacking_plan_csv(plan_path, plan)
+        try:
+            write_stacking_plan_csv(plan_path, plan)
+        except PermissionError as exc:
+            messagebox.showerror(
+                "Erreur de permission",
+                f"Impossible d'écrire le fichier :\n{plan_path}\n{exc}"
+            )
+            return
         messagebox.showinfo(
             "Plan de stacking mis à jour",
             f"Le plan a été régénéré :\n{plan_path}\n({len(plan)} fichiers)"

--- a/stack_plan.py
+++ b/stack_plan.py
@@ -131,34 +131,39 @@ def generate_stacking_plan(
 def write_stacking_plan_csv(csv_path: str, rows: Iterable[Dict[str, str]]) -> None:
     """Write stacking plan rows to ``csv_path`` in UTF-8."""
     os.makedirs(os.path.dirname(csv_path), exist_ok=True)
-    with open(csv_path, "w", encoding="utf-8", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(
-            [
-                "order",
-                "batch_id",
-                "mount",
-                "bortle",
-                "telescope",
-                "session_date",
-                "filter",
-                "exposure",
-                "file_path",
-            ]
-        )
-        for row in rows:
+    try:
+        with open(csv_path, "w", encoding="utf-8", newline="") as f:
+            writer = csv.writer(f)
             writer.writerow(
                 [
-                    row.get("order", ""),
-                    row.get("batch_id", ""),
-                    row.get("mount", ""),
-                    row.get("bortle", ""),
-                    row.get("telescope", ""),
-                    row.get("session_date", ""),
-                    row.get("filter", ""),
-                    row.get("exposure", ""),
-                    row.get("file_path", ""),
+                    "order",
+                    "batch_id",
+                    "mount",
+                    "bortle",
+                    "telescope",
+                    "session_date",
+                    "filter",
+                    "exposure",
+                    "file_path",
                 ]
             )
+            for row in rows:
+                writer.writerow(
+                    [
+                        row.get("order", ""),
+                        row.get("batch_id", ""),
+                        row.get("mount", ""),
+                        row.get("bortle", ""),
+                        row.get("telescope", ""),
+                        row.get("session_date", ""),
+                        row.get("filter", ""),
+                        row.get("exposure", ""),
+                        row.get("file_path", ""),
+                    ]
+                )
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot write to '{csv_path}'. File is in use or the directory is not writable."
+        ) from exc
 
     return None


### PR DESCRIPTION
## Summary
- handle `PermissionError` when writing the stacking plan CSV
- show a message box when writing fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b5b93f28832fa93be19855b4f113