### PR TITLE
Handle stack plan write errors

### DIFF
--- a/analyse_gui.py
+++ b/analyse_gui.py
@@ -4009,7 +4009,15 @@ class AstroImageAnalyzerGUI:
                 messagebox.showwarning(self._('msg_warning'), self._('msg_export_no_images'), parent=window)
                 return
             csv_path = os.path.join(os.path.dirname(self.output_log.get()), 'stack_plan.csv')
-            write_stacking_plan_csv(csv_path, rows)
+            try:
+                write_stacking_plan_csv(csv_path, rows)
+            except PermissionError as e:
+                messagebox.showerror(
+                    self._('msg_error'),
+                    self._('msg_stack_plan_write_error', path=csv_path, e=e),
+                    parent=window,
+                )
+                return
             messagebox.showinfo(self._('msg_info'), csv_path, parent=window)
             window.destroy()
 

--- a/zone.py
+++ b/zone.py
@@ -130,6 +130,7 @@ translations = {
         'msg_tkinter_error': "Erreur Tkinter:\n{e}", 'msg_unexpected_error': "Erreur inattendue:\n{e}",
         'msg_organize_done': "{count} fichiers organisés.",
         'msg_organize_failed': "Organisation échouée: {e}",
+        'msg_stack_plan_write_error': "Impossible d'écrire '{path}'. Fichier utilisé ou dossier non accessible.",
 
         # --- Fenêtre Visualisation ---
         'visu_window_title': "Visualisation des résultats", 'visu_tab_snr_dist': "Distribution SNR", 'visu_tab_snr_comp': "Comparaison SNR", 'visu_tab_sat_trails': "Traînées Détectées", 'visu_tab_raw_data': "Données Détaillées", 'visu_tab_recom': "Recommandations Stacking",
@@ -281,6 +282,7 @@ translations = {
         'msg_tkinter_error': "Tkinter Error:\n{e}", 'msg_unexpected_error': "Unexpected error:\n{e}",
         'msg_organize_done': "{count} files organized.",
         'msg_organize_failed': "Organization failed: {e}",
+        'msg_stack_plan_write_error': "Cannot write '{path}'. File is in use or the directory is not writable.",
 
         # --- Visualization Window ---
         'visu_window_title': "Results Visualization", 'visu_tab_snr_dist': "SNR Distribution", 'visu_tab_snr_comp': "SNR Comparison", 'visu_tab_sat_trails': "Detected Trails", 'visu_tab_raw_data': "Detailed Data", 'visu_tab_recom': "Stacking Recommendations",


### PR DESCRIPTION
## Summary
- handle permission errors when generating a stacking plan
- add translations for the stack plan write error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840f338bdc832fa97b963b95752ec6